### PR TITLE
Fix symlink-to-directory crash in scanLocalFiles

### DIFF
--- a/internal/cmd/push.go
+++ b/internal/cmd/push.go
@@ -325,6 +325,17 @@ func scanLocalFiles(root string) (map[string]string, error) {
 			return nil
 		}
 
+		// Symlinks may point to directories; resolve and skip those.
+		if d.Type()&fs.ModeSymlink != 0 {
+			fi, err := os.Stat(path)
+			if err != nil {
+				return nil // skip broken symlinks
+			}
+			if fi.IsDir() {
+				return nil
+			}
+		}
+
 		// Compute SHA-256 hash.
 		data, err := os.ReadFile(path)
 		if err != nil {


### PR DESCRIPTION
## Summary
- `scanLocalFiles` crashes when the vault contains a symlink pointing to a directory, causing a reconnect loop every 60s
- After the existing `d.IsDir()` check, resolve symlink targets with `os.Stat()` and skip those pointing to directories
- Broken symlinks are also skipped gracefully

Fixes #1

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Verified manually that `os.ReadFile` fails on symlink-to-dir and the fix correctly detects/skips them